### PR TITLE
fix empty list by initialising job book with readonly job book

### DIFF
--- a/src/main/java/seedu/address/model/jobapplication/ModelManager.java
+++ b/src/main/java/seedu/address/model/jobapplication/ModelManager.java
@@ -30,7 +30,7 @@ public class ModelManager implements Model {
 
         logger.fine("Initializing with address book: " + jobBook + " and user prefs " + userPrefs);
 
-        this.jobBook = new JobBook(new JobBook());
+        this.jobBook = new JobBook(jobBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredApplications = new FilteredList<>(this.jobBook.getApplicationList());
     }


### PR DESCRIPTION
Resolves #80 

This pull request fixes a bug in the `ModelManager` constructor where the `jobBook` was not being initialized correctly. The change ensures that the `ModelManager` uses the provided `jobBook` instead of creating a new, empty one.

Bug fix:

* Corrected the initialization of `jobBook` in the `ModelManager` constructor to use the provided `jobBook` parameter instead of always creating a new `JobBook` instance.