### PR TITLE
Refactor Test Utilities from Person to JobApplication

### DIFF
--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -12,7 +12,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_STATUS = new Prefix("s/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
 
-     // to remove
+    // to remove
     public static final Prefix PREFIX_PHONE = new Prefix("p/");
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");

--- a/src/test/java/seedu/address/testutil/JobApplicationBuilder.java
+++ b/src/test/java/seedu/address/testutil/JobApplicationBuilder.java
@@ -80,7 +80,7 @@ public class JobApplicationBuilder {
     }
 
     /**
-     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code JobApplication} 
+     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code JobApplication}
      * that we are building.
      */
     public JobApplicationBuilder withTags(String... tags) {

--- a/src/test/java/seedu/address/testutil/JobApplicationUtil.java
+++ b/src/test/java/seedu/address/testutil/JobApplicationUtil.java
@@ -1,18 +1,18 @@
 package seedu.address.testutil;
 
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.time.format.DateTimeFormatter;
-import java.util.Set;
+// import java.util.Set;
 
 import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.EditCommand.EditJobApplicationDescriptor;
+// import seedu.address.logic.commands.EditCommand.EditJobApplicationDescriptor;
 import seedu.address.model.jobapplication.JobApplication;
-import seedu.address.model.tag.Tag;
+// import seedu.address.model.tag.Tag;
 
 /**
  * A utility class for JobApplication.
@@ -43,27 +43,28 @@ public class JobApplicationUtil {
         return sb.toString();
     }
 
-    /**
-     * Returns the part of command string for the given {@code EditJobApplicationDescriptor}'s details.
-     */
-    public static String getEditJobApplicationDescriptorDetails(EditJobApplicationDescriptor descriptor) {
-        StringBuilder sb = new StringBuilder();
-        descriptor.getCompanyName().ifPresent(companyName -> 
-            sb.append(PREFIX_NAME).append(companyName).append(" "));
-        descriptor.getRole().ifPresent(role -> 
-            sb.append(PREFIX_ROLE).append(role).append(" "));
-        descriptor.getDeadline().ifPresent(deadline -> 
-            sb.append(PREFIX_DEADLINE).append(deadline.format(FORMATTER)).append(" "));
-        descriptor.getStatus().ifPresent(status -> 
-            sb.append(PREFIX_STATUS).append(status.toString()).append(" "));
-        if (descriptor.getTags().isPresent()) {
-            Set<Tag> tags = descriptor.getTags().get();
-            if (tags.isEmpty()) {
-                sb.append(PREFIX_TAG);
-            } else {
-                tags.forEach(s -> sb.append(PREFIX_TAG).append(s.tagName).append(" "));
-            }
-        }
-        return sb.toString();
-    }
+    //    /**
+    //     * Returns the part of command string for the given {@code EditJobApplicationDescriptor}'s details.
+    //     */
+    //
+    //    public static String getEditJobApplicationDescriptorDetails(EditJobApplicationDescriptor descriptor) {
+    //        StringBuilder sb = new StringBuilder();
+    //        descriptor.getCompanyName().ifPresent(companyName ->
+    //            sb.append(PREFIX_NAME).append(companyName).append(" "));
+    //        descriptor.getRole().ifPresent(role ->
+    //            sb.append(PREFIX_ROLE).append(role).append(" "));
+    //        descriptor.getDeadline().ifPresent(deadline ->
+    //            sb.append(PREFIX_DEADLINE).append(deadline.format(FORMATTER)).append(" "));
+    //        descriptor.getStatus().ifPresent(status ->
+    //            sb.append(PREFIX_STATUS).append(status.toString()).append(" "));
+    //        if (descriptor.getTags().isPresent()) {
+    //            Set<Tag> tags = descriptor.getTags().get();
+    //            if (tags.isEmpty()) {
+    //                sb.append(PREFIX_TAG);
+    //            } else {
+    //                tags.forEach(s -> sb.append(PREFIX_TAG).append(s.tagName).append(" "));
+    //            }
+    //        }
+    //        return sb.toString();
+    //     }
 }


### PR DESCRIPTION
## Overview
Refactored test utility classes and CLI syntax definitions to support `JobApplication` entities instead of `Person` entities.

## Changes

### New Files
- **`JobApplicationBuilder`**: Test utility for building `JobApplication` objects with fluent API and sensible defaults

### Updated Files
- **`JobApplicationUtil`** (renamed from `PersonUtil`): Command string generation for job applications with `DateTimeFormatter` for deadline formatting
- **`CliSyntax`**: Simplified prefix definitions for job application fields
  - To be removed (future planning): `PREFIX_PHONE`, `PREFIX_EMAIL`, `PREFIX_ADDRESS`
  - Retained: `PREFIX_ROLE` (`r/`), `PREFIX_DEADLINE` (`d/`), `PREFIX_STATUS` (`s/`), `PREFIX_TAG` (`t/`)