### PR TITLE
update ui class diagram naming from person to job application context

### DIFF
--- a/docs/diagrams/UiClassDiagram.puml
+++ b/docs/diagrams/UiClassDiagram.puml
@@ -11,8 +11,8 @@ Class UiManager
 Class MainWindow
 Class HelpWindow
 Class ResultDisplay
-Class PersonListPanel
-Class PersonCard
+Class JobApplicationListPanel
+Class JobApplicationCard
 Class StatusBarFooter
 Class CommandBox
 }
@@ -32,26 +32,26 @@ UiManager .left.|> Ui
 UiManager -down-> "1" MainWindow
 MainWindow *-down->  "1" CommandBox
 MainWindow *-down-> "1" ResultDisplay
-MainWindow *-down-> "1" PersonListPanel
+MainWindow *-down-> "1" JobApplicationListPanel
 MainWindow *-down-> "1" StatusBarFooter
 MainWindow --> "0..1" HelpWindow
 
-PersonListPanel -down-> "*" PersonCard
+JobApplicationListPanel -down-> "*" JobApplicationCard
 
 MainWindow -left-|> UiPart
 
 ResultDisplay --|> UiPart
 CommandBox --|> UiPart
-PersonListPanel --|> UiPart
-PersonCard --|> UiPart
+JobApplicationListPanel --|> UiPart
+JobApplicationCard --|> UiPart
 StatusBarFooter --|> UiPart
 HelpWindow --|> UiPart
 
-PersonCard ..> Model
+JobApplicationCard ..> Model
 UiManager -right-> Logic
 MainWindow -left-> Logic
 
-PersonListPanel -[hidden]left- HelpWindow
+JobApplicationListPanel -[hidden]left- HelpWindow
 HelpWindow -[hidden]left- CommandBox
 CommandBox -[hidden]left- ResultDisplay
 ResultDisplay -[hidden]left- StatusBarFooter


### PR DESCRIPTION
This pull request updates the UI class diagram to reflect a shift in focus from "Person" entities to "JobApplication" entities. The changes ensure that the diagram accurately represents the current UI structure and relationships.

**UI class renaming and relationship updates:**

* Renamed `PersonListPanel` and `PersonCard` classes to `JobApplicationListPanel` and `JobApplicationCard` to reflect the new domain focus.
* Updated all associations, inheritances, and dependencies in the diagram to use `JobApplicationListPanel` and `JobApplicationCard` instead of their previous counterparts.