### PR TITLE
feat: add role indexing for find command too

### DIFF
--- a/src/main/java/seedu/job/model/jobapplication/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/job/model/jobapplication/NameContainsKeywordsPredicate.java
@@ -30,8 +30,11 @@ public class NameContainsKeywordsPredicate implements Predicate<JobApplication> 
     @Override
     public boolean test(JobApplication jobApplication) {
         String company = jobApplication.getCompanyName();
+        String role = jobApplication.getRole();
+        String position = company + " " + role;
+
         return keywords.stream().anyMatch(
-            keyword -> StringUtil.containsWordIgnoreCase(company, keyword)
+            keyword -> StringUtil.containsWordIgnoreCase(position, keyword)
         );
     }
 


### PR DESCRIPTION
This pull request updates the logic for keyword matching in job applications to improve search accuracy. Instead of matching keywords only against the company name, the search now considers both the company name and the job role together.

**Improvements to keyword matching:**

* Updated the `test` method in `NameContainsKeywordsPredicate.java` to match keywords against a combination of the company name and role, rather than just the company name.