### PR TITLE
fix: include "role" as part of find job command hint

### DIFF
--- a/src/main/java/seedu/job/logic/jobcommands/FindCommand.java
+++ b/src/main/java/seedu/job/logic/jobcommands/FindCommand.java
@@ -16,7 +16,7 @@ public class FindCommand extends Command {
     public static final String COMMAND_WORD = "find";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all job applications whose company names or "
-            + "role contain any of the specified keywords (case-insensitive) and displays them as a list with"
+            + "roles contain any of the specified keywords (case-insensitive) and displays them as a list with"
             + " index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " TikTok Jane Street HRT";


### PR DESCRIPTION
This pull request updates the user-facing documentation for the `FindCommand` to clarify its search functionality.

* Documentation improvement: The `MESSAGE_USAGE` string in `FindCommand.java` now specifies that the command searches for job applications whose company names or roles contain any of the specified keywords, rather than just company names.

Resolves #229 #227 