### PR TITLE
docs: update description of partial match

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -467,7 +467,7 @@ Format: `find KEYWORD [MORE_KEYWORDS]`
    * An application is returned if either field contains at least one keyword.
 
 2. **Case-Insensitive**: The search is case-insensitive.
-   * `tiktok` matches "TikTok", "TikTok Inc", or "BigTikTok".
+   * `tiktok` matches "TikTok", "TikTok Inc", or "TikTok Singapore".
 
 3. **Partial Matching**: Keywords match partial words.
    * `engineer` matches "Software Engineer", "Engineering Manager".


### PR DESCRIPTION
This pull request updates the documentation in `docs/UserGuide.md` to clarify the examples used in the case-insensitive search section.

Documentation improvement:

* Updated the example for case-insensitive matching to use "TikTok Singapore" instead of "BigTikTok" for greater clarity and relevance.

Resolves #205 #253 